### PR TITLE
HKMOB-610 Reset UIDatePicker of ios14 to UIDatePickerStyleWheels

### DIFF
--- a/src/ios/DatePicker.m
+++ b/src/ios/DatePicker.m
@@ -259,6 +259,10 @@
   if (locale) {
     [self.datePicker setLocale:locale];
   }
+    
+  if (@available(iOS 14, *)) {
+    self.datePicker.preferredDatePickerStyle = UIDatePickerStyleWheels;
+  }
 }
 
 - (NSDateFormatter *)createISODateFormatter:(NSString *)format timezone:(NSTimeZone *)timezone {


### PR DESCRIPTION
Reset UIDatePicker of ios14 to UIDatePickerStyleWheels

impact scope:
if is ios14, set preferredDatePickerStyle of UIDatePicker for UIDatePickerStyleWheels.